### PR TITLE
fix: fix auth development error

### DIFF
--- a/app/controllers/auth_controller.ts
+++ b/app/controllers/auth_controller.ts
@@ -3,7 +3,6 @@ import { signUpSchema } from '#validators/auth'
 import { cuid } from '@adonisjs/core/helpers'
 import type { HttpContext } from '@adonisjs/core/http'
 import app from '@adonisjs/core/services/app'
-import { preparePhoneNumber } from './profile_controller.js'
 
 export default class AuthController {
   /**
@@ -467,6 +466,8 @@ export default class AuthController {
     }
 
     if (payload.phoneNumber) {
+      // Import the function dynamically
+      const { preparePhoneNumber } = await import('./profile_controller.js')
       payload.phoneNumber = preparePhoneNumber(payload.phoneNumber)
     }
 


### PR DESCRIPTION
### Corrige o seguinte erro de modo dev:

Ao chamar as rotas de auth no frontend, acontecia isso e a aplicação parava de rodar.
```bash
 process.nextTick(() => { throw err; });
                           ^
Error: The import "./profile_controller.js" is not imported dynamically from app/controllers/auth_controller.ts.
You must use dynamic import to make it reloadable (HMR) with hot-hook.
    at DynamicImportChecker.ensureFileIsImportedDynamicallyFromParent (file:///Users/alexcustodio/Projetos/simbora/simbora-api/node_modules/.pnpm/hot-hook@0.3.1/node_modules/hot-hook/build/src/dynamic_import_checker.js:30:19)
    ```
Corrigi o erro ajustando a importação.

   